### PR TITLE
Fix OTA_* definitions for golden-image

### DIFF
--- a/examples/oap/golden-image/arch/cpu/cc26xx-cc13xx/module-macros.h
+++ b/examples/oap/golden-image/arch/cpu/cc26xx-cc13xx/module-macros.h
@@ -52,8 +52,7 @@
  * Max area available for the main firmware on internal flash, including
  * metadata
  */
-#define OTA_CONF_MAIN_FW_MAX_LEN (INTERNAL_FLASH_LENGTH - FLASH_FW_LENGTH - \
-                                  CCFG_LENGTH)
+#define OTA_CONF_MAIN_FW_MAX_LEN (FLASH_FW_LENGTH + OTA_METADATA_LEN)
 
 /*
  * Start address of main firmware on internal flash


### PR DESCRIPTION
I've done some tests using this project and achieved encouraging results using the TI's cc2560 launchpad. This OTA engine is pretty close of a functional feature.

A problem I found is that OTA_CONF_METADATA_OFFSET constant is evaluated different in bootloader execution and in golden-image execution, in such a way that the golden-image is unable to find the metadata.

```
Evaluating constants for golden image
FLASH_FW_LENGTH: 1DF9C
INTERNAL_FLASH_LENGTH: 20000
CCFG_LENGTH: 58
OTA_CONF_MAIN_FW_MAX_LEN: 200C
OTA_CONF_MAIN_FW_BASE: 2000
OTA_METADATA_LEN: C
OTA_CONF_METADATA_OFFSET: 2000
```

```
Evaluating constants for bootloader
FLASH_FW_LENGTH: 2000
INTERNAL_FLASH_LENGTH: 20000
CCFG_LENGTH: 58
OTA_CONF_MAIN_FW_MAX_LEN: 1DFA8
OTA_CONF_MAIN_FW_BASE: 2000
OTA_METADATA_LEN: C
OTA_CONF_METADATA_OFFSET: 1DF9C
```

Given the difference between OTA_CONF_METADATA_OFFSET on the two spaces, the function ```bool ota_ext_flash_read_metadata()``` is unable to find any metadata stored on the external flash when called by golden-image.

```c
bool
ota_ext_flash_read_metadata(uint8_t area, ota_firmware_metadata_t *md)
{
...
  read_addr = area * OTA_EXT_FLASH_AREA_LEN + OTA_METADATA_OFFSET;

  success = ext_flash_read(NULL, read_addr, sizeof(ota_firmware_metadata_t),
                           (uint8_t *)md);
...
}
```

The simplest solution is to change the definition of OTA_CONF_MAIN_FW_MAX_LEN, from:

```c
#define OTA_CONF_MAIN_FW_MAX_LEN (INTERNAL_FLASH_LENGTH - FLASH_FW_LENGTH - \
                                   CCFG_LENGTH)
```

To:

```c
#define OTA_CONF_MAIN_FW_MAX_LEN (FLASH_FW_LENGTH + OTA_METADATA_LEN)
```

Since the golden-image is the main firmware, there is no need of any further calculations to find the main firmware max len. This way, the constants become:

```
Evaluating constants for golden image
FLASH_FW_LENGTH: 1DF9C
INTERNAL_FLASH_LENGTH: 20000
CCFG_LENGTH: 58
OTA_CONF_MAIN_FW_MAX_LEN: 1DFA8
OTA_CONF_MAIN_FW_BASE: 2000
OTA_METADATA_LEN: C
OTA_CONF_METADATA_OFFSET: 1DF9C
```

And this makes OTA_CONF_METADATA_OFFSET compatible with the bootloader definition.

I spent some time to discover this problem, I hope this PR saves some of your time and this project will become a feature of Contiki NG in the future.

Best regards

