### PR TITLE
adding an encoding argument to bytearray

### DIFF
--- a/tools/oap/generate-metadata.py
+++ b/tools/oap/generate-metadata.py
@@ -67,7 +67,7 @@ class FirmwareFile(object):
         firmware_is_hex = False
 
         if have_magic:
-            file_type = bytearray(magic.from_file(path, True))
+            file_type = bytearray(magic.from_file(path, True), 'utf8')
 
             # from_file() returns bytes with PY3, str with PY2. This comparison
             # will be True in both cases"""


### PR DESCRIPTION
line 70 passes a string object to a bytearray and outputs "string argument without an encoding" error.  Supplying an encoding argument fixes the error