### PR TITLE
adding "python3" for Ubuntu 20.04 use case

### DIFF
--- a/examples/oap/Makefile
+++ b/examples/oap/Makefile
@@ -53,8 +53,14 @@ $(BOOTLOADER): FORCE
 $(GOLDEN_IMAGE): FORCE
 	$(MAKE) -C $(dir $@) TARGET=$(TARGET) BOARD=$(BOARD) $(notdir $@)
 
+OS_VERS := $(shell lsb_release -a 2>/dev/null | grep Description | awk '{ print $$2 "-" $$3 }')
+
 $(METADATA): $(GOLDEN_IMAGE)
+ifeq ($(OS_VERS), Ubuntu-20.04)
+	python3 $(GENERATE_METADATA) -o $@ -O $(METADATA_OFFSET) $<
+else
 	python $(GENERATE_METADATA) -o $@ -O $(METADATA_OFFSET) $<
+endif
 
 $(FINAL_IMAGE): $(BOOTLOADER) $(GOLDEN_IMAGE) $(METADATA) FORCE
 	srec_cat \


### PR DESCRIPTION
Ubuntu 20.04 uses python3 and doesn't run this make file, unless "GENERATE_METADATA" is called by python3. 

the added lines fetches the OS' version (OS_VERS). If the OS version is Ubuntu 20.04, then it calls the "GENERATE_METADATA" via python3, otherwise uses the original call.